### PR TITLE
Global array take 2.

### DIFF
--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -6,6 +6,18 @@ global L: Field = 10; // Unused globals currently allowed
 global N: Field = 5;
 //global N: Field = 5; // Uncomment to see duplicate globals error 
 
+// Global arrays that match the input arrays c and d.
+global GlobalC: [Field; 3] = [3, 3, 3];
+global GlobalD: [Field; 5] = [5, 5, 5, 5, 5];
+
+// global badGlobal = if M == 32 {
+//      constrain 1 == 1;
+// };
+
+// global badGlobal2 = for i in 0..1 {
+//      constrain i == 0;
+// };
+
 struct Dummy {
      x: [Field; N],
      y: [Field; foo::MAGIC_NUMBER]

--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -10,17 +10,17 @@ global N: Field = 5;
 global GlobalC: [Field; 3] = [3, 3, 3];
 global GlobalD: [Field; 5] = [5, 5, 5, 5, 5];
 
-global badGlobal = if M == 32 {
-     constrain 1 == 1;
-};
+// global badGlobal = if M == 32 {
+//      constrain 1 == 1;
+// };
 
-global badGlobal2 = for i in 0..1 {
-     constrain i == 0;
-};
+// global badGlobal2 = for i in 0..1 {
+//      constrain i == 0;
+// };
 
-global BAD = 10;
-global A = [BAD, ELEMS];
-global ELEMS = 11;
+// global BAD = 10;
+// global A = [BAD, ELEMS];
+// global ELEMS = 11;
 
 struct Dummy {
      x: [Field; N],

--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -10,9 +10,9 @@ global N: Field = 5;
 global GlobalC: [Field; 3] = [3, 3, 3];
 global GlobalD: [Field; 5] = [5, 5, 5, 5, 5];
 
-// global badGlobal = if M == 32 {
-//      constrain 1 == 1;
-// };
+global badGlobal = if M == 32 {
+     constrain 1 == 1;
+};
 
 // global badGlobal2 = for i in 0..1 {
 //      constrain i == 0;

--- a/crates/nargo/tests/test_data/global_consts/src/main.nr
+++ b/crates/nargo/tests/test_data/global_consts/src/main.nr
@@ -14,9 +14,13 @@ global badGlobal = if M == 32 {
      constrain 1 == 1;
 };
 
-// global badGlobal2 = for i in 0..1 {
-//      constrain i == 0;
-// };
+global badGlobal2 = for i in 0..1 {
+     constrain i == 0;
+};
+
+global BAD = 10;
+global A = [BAD, ELEMS];
+global ELEMS = 11;
 
 struct Dummy {
      x: [Field; N],

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -151,7 +151,6 @@ impl DefCollector {
         // We must first resolve and intern the globals before we can resolve any stmts inside each function.
         // Each function uses its own resolver with a newly created ScopeForest, and must be resolved again to be within a function's scope
         let file_global_ids = resolve_globals(context, def_collector.collected_globals, crate_id, errors);
-
         resolve_structs(context, def_collector.collected_types, crate_id, errors);
 
         // Before we resolve any function symbols we must go through our impls and
@@ -249,7 +248,7 @@ fn resolve_globals(
         let path_resolver =
             StandardPathResolver::new(ModuleId { local_id: global.module_id, krate: crate_id });
 
-        let mut resolver = Resolver::new(
+        let resolver = Resolver::new(
             &mut context.def_interner,
             &path_resolver,
             &context.def_maps,
@@ -264,11 +263,10 @@ fn resolve_globals(
                 file_id: global.file_id,
                 errors: vecmap(errs, |err| err.into_diagnostic()),
             })
+        } else {
+            context.def_interner.update_global(global.stmt_id, hir_stmt);
+            context.def_interner.push_global(global.stmt_id, name.clone(), global.module_id);
         }
-
-        context.def_interner.update_global(global.stmt_id, hir_stmt);
-
-        context.def_interner.push_global(global.stmt_id, name.clone(), global.module_id);
 
         global_ids.push((global.file_id, global.stmt_id));
     }

--- a/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
+++ b/crates/noirc_frontend/src/hir/def_collector/dc_crate.rs
@@ -150,7 +150,7 @@ impl DefCollector {
 
         // We must first resolve and intern the globals before we can resolve any stmts inside each function.
         // Each function uses its own resolver with a newly created ScopeForest, and must be resolved again to be within a function's scope
-        let file_global_ids = resolve_globals(context, def_collector.collected_globals, crate_id);
+        let file_global_ids = resolve_globals(context, def_collector.collected_globals, crate_id, errors);
 
         resolve_structs(context, def_collector.collected_types, crate_id, errors);
 
@@ -241,6 +241,7 @@ fn resolve_globals(
     context: &mut Context,
     globals: Vec<UnresolvedGlobal>,
     crate_id: CrateId,
+    errors: &mut Vec<CollectedErrors>,
 ) -> Vec<(FileId, StmtId)> {
     let mut global_ids = Vec::new();
 
@@ -257,7 +258,13 @@ fn resolve_globals(
 
         let name = global.stmt_def.pattern.name_ident().clone();
 
-        let hir_stmt = resolver.resolve_global_let(global.stmt_def);
+        let (hir_stmt, errs) = resolver.resolve_global_let(global.stmt_def);
+        if !errs.is_empty() {
+            errors.push(CollectedErrors {
+                file_id: global.file_id,
+                errors: vecmap(errs, |err| err.into_diagnostic()),
+            })
+        }
 
         context.def_interner.update_global(global.stmt_id, hir_stmt);
 

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -479,13 +479,25 @@ impl<'a> Resolver<'a> {
     }
 
     pub fn resolve_global_let(&mut self, let_stmt: crate::LetStatement) -> HirStatement {
-        let expression = self.resolve_expression(let_stmt.expression);
-        let definition = DefinitionKind::Global(expression);
-        HirStatement::Let(HirLetStatement {
-            pattern: self.resolve_pattern(let_stmt.pattern, definition),
-            r#type: self.resolve_type(let_stmt.r#type),
-            expression,
-        })
+        match let_stmt.expression.kind {
+            ExpressionKind::Literal(_) => {
+                let expression = self.resolve_expression(let_stmt.expression);
+                let definition = DefinitionKind::Global(expression);
+                HirStatement::Let(HirLetStatement {
+                    pattern: self.resolve_pattern(let_stmt.pattern, definition),
+                    r#type: self.resolve_type(let_stmt.r#type),
+                    expression,
+                })
+            }
+            _ => {
+                self.push_err(ResolverError::Expected { 
+                    span: let_stmt.expression.span, 
+                    expected: "globals can only be array, bool, integer or field literals".to_owned(), 
+                    got: let_stmt.expression.kind.to_string(),
+                });
+                HirStatement::Error
+            }
+        }
     }
 
     pub fn resolve_stmt(&mut self, stmt: Statement) -> HirStatement {

--- a/crates/noirc_frontend/src/hir/resolution/resolver.rs
+++ b/crates/noirc_frontend/src/hir/resolution/resolver.rs
@@ -478,24 +478,29 @@ impl<'a> Resolver<'a> {
         }
     }
 
-    pub fn resolve_global_let(&mut self, let_stmt: crate::LetStatement) -> HirStatement {
+    pub fn resolve_global_let(
+        &mut self, 
+        let_stmt: crate::LetStatement
+    ) -> (HirStatement, Vec<ResolverError>) {
         match let_stmt.expression.kind {
             ExpressionKind::Literal(_) => {
+                print!("*** 1\n");
                 let expression = self.resolve_expression(let_stmt.expression);
                 let definition = DefinitionKind::Global(expression);
-                HirStatement::Let(HirLetStatement {
+                (HirStatement::Let(HirLetStatement {
                     pattern: self.resolve_pattern(let_stmt.pattern, definition),
                     r#type: self.resolve_type(let_stmt.r#type),
                     expression,
-                })
+                }), self.errors)
             }
             _ => {
+                print!("*** 2\n");
                 self.push_err(ResolverError::Expected { 
                     span: let_stmt.expression.span, 
                     expected: "globals can only be array, bool, integer or field literals".to_owned(), 
                     got: let_stmt.expression.kind.to_string(),
                 });
-                HirStatement::Error
+                (HirStatement::Error, self.errors)
             }
         }
     }

--- a/crates/noirc_frontend/src/parser/parser.rs
+++ b/crates/noirc_frontend/src/parser/parser.rs
@@ -76,7 +76,7 @@ fn global_declaration() -> impl NoirParser<TopLevelStatement> {
     );
     let p = then_commit(p, global_type_annotation());
     let p = then_commit_ignore(p, just(Token::Assign));
-    let p = then_commit(p, literal().map_with_span(Expression::new)); // XXX: this should be a literal
+    let p = then_commit(p, expression());
     p.map(LetStatement::new_let).map(TopLevelStatement::Global)
 }
 
@@ -268,7 +268,8 @@ fn global_type_annotation() -> impl NoirParser<UnresolvedType> {
             UnresolvedType::Bool(_) => UnresolvedType::Bool(Comptime::Yes(None)),
             UnresolvedType::Integer(_, sign, size) => {
                 UnresolvedType::Integer(Comptime::Yes(None), sign, size)
-            }
+            },
+            UnresolvedType::Array(size, elem) => UnresolvedType::Array(size, elem),
             other => other,
         })
         .or_not()


### PR DESCRIPTION
This is working for 

```
global GlobalC: [Field; 3] = [3, 3, 3];
global GlobalD: [Field; 5] = [5, 5, 5, 5, 5];
```

and compiles fine. 

When we try a global that should fail. e.g.,

```
global badGlobal = if M == 32 {
      constrain 1 == 1;
};
```

we get a panic

```
thread 'main' panicked at 'ice: all let statement ids should correspond to a let statement in the interner', crates/noirc_frontend/src/node_interner.rs:443:26
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

so we need to add some error handling.